### PR TITLE
Fix wrong permission assert for channel deletion

### DIFF
--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -387,7 +387,7 @@ class Channel(SlottedModel, Permissible):
                 self.delete_message(msg)
 
     def delete(self, **kwargs):
-        assert (self.is_dm or self.guild.can(self.client.state.me, Permissions.MANAGE_GUILD)), 'Invalid Permissions'
+        assert (self.is_dm or self.guild.can(self.client.state.me, Permissions.MANAGE_CHANNELS)), 'Invalid Permissions'
         self.client.api.channels_delete(self.id, **kwargs)
 
     def close(self):


### PR DESCRIPTION
According to both Discord UI and [API Documentation](https://discordapp.com/developers/docs/resources/channel#deleteclose-channel), deleting a channel requires the MANAGE_CHANNELS permission and not the MANAGE_GUILD one.